### PR TITLE
Add the possibility to provide the content to process

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -144,7 +144,12 @@ HTMLProcessor.prototype._replaceBlocks = function (blocks, filepath) {
 
 // Process the file content
 HTMLProcessor.prototype.process = function (filepath) {
-  this.content = fs.readFileSync(filepath).toString();
+  return this.processContent(fs.readFileSync(filepath).toString(), filepath);
+};
+
+// Process the input content
+HTMLProcessor.prototype.processContent = function (content, filepath) {
+  this.content = content;
   this.linefeed = /\r\n/g.test(this.content) ? '\r\n' : '\n';
 
   // Parse the file content to look for build comment blocks


### PR DESCRIPTION
I've just written a Gulp plugin ([gulp-htmlprocessor](https://github.com/Nesk/gulp-htmlprocessor)) based on this project and providing the same features as [grunt-processhtml](https://github.com/dciccale/grunt-processhtml).

However, to achieve this, I had to slightly edit the standalone library. In the Gulp way, plugins rarely take file paths as inputs, but their contents. So I just added a `processContent()` method which requires the file contents and its path.
