### PR TITLE
Inline modifier for embedding CSS and JavaScript

### DIFF
--- a/lib/blocktypes.js
+++ b/lib/blocktypes.js
@@ -13,13 +13,72 @@ var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
 
+function obtainStyles(block, html, baseDir) {
+  var hrefRegEx = /.*href=[\'"]([^\'"]*)[\'"].*/gi;
+
+  return obtainAssets(hrefRegEx, block, html, baseDir);
+}
+
+function obtainScripts(block, html, baseDir) {
+  var srcRegEx = /.*src=[\'"]([^\'"]*)[\'"].*/gi;
+
+  return obtainAssets(srcRegEx, block, html, baseDir);
+}
+
+function obtainAssets(assetPathRegEx, block, html, baseDir) {
+  var assetpath,
+      fileContent,
+      match,
+      assets = [];
+
+  if (block.asset) {
+    assetpath = path.join(baseDir, block.asset);
+    fileContent = fs.readFileSync(assetpath).toString();
+
+    return [fileContent];
+  }
+
+  while ((match = assetPathRegEx.exec(html)) !== null) {
+    assetpath = path.join(baseDir, match[1]);
+    fileContent = fs.readFileSync(assetpath).toString();
+
+    assets.push(fileContent);
+  }
+
+  return assets;
+}
+
 // Define default block types
 module.exports = {
-  css: function (content, block, blockLine, blockContent) {
+  css: function (content, block, blockLine, blockContent, filepath) {
+    var replacement,
+        styles = [];
+
+    if (block.inline) {
+      styles = obtainStyles(block, blockContent, this.options.includeBase || path.dirname(filepath));
+      replacement = block.indent + '<style>' + this.linefeed +
+                    styles.join(this.linefeed) +
+                    block.indent + '</style>';
+
+      return content.split(blockLine).join(replacement);
+    }
+
     return content.replace(blockLine, block.indent + '<link rel="stylesheet" href="' + block.asset + '">');
   },
 
-  js: function (content, block, blockLine, blockContent) {
+  js: function (content, block, blockLine, blockContent, filepath) {
+    var replacement,
+        scripts = [];
+
+    if (block.inline) {
+      scripts = obtainScripts(block, blockContent, this.options.includeBase || path.dirname(filepath));
+      replacement = block.indent + '<script>' + this.linefeed +
+                    scripts.join(this.linefeed) +
+                    block.indent + '</script>';
+
+      return content.split(blockLine).join(replacement);
+    }
+
     return content.replace(blockLine, block.indent + '<script src="' + block.asset + '"><\/script>');
   },
 

--- a/lib/blocktypes.js
+++ b/lib/blocktypes.js
@@ -78,7 +78,7 @@ module.exports = {
       }
 
       // Add indentation and remove any last new line
-      fileContent = block.indent + fileContent.replace(/\n$/, '');
+      fileContent = block.indent + fileContent.replace(/\r\n$/, '');
 
       while ((i = content.indexOf(blockLine)) !== -1) {
         content = content.substring(0, i) + fileContent + content.substring(i + l);

--- a/lib/blocktypes.js
+++ b/lib/blocktypes.js
@@ -12,6 +12,7 @@
 var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
+var url = require('url');
 
 function obtainStyles(block, html, baseDir) {
   var hrefRegEx = /.*href=[\'"]([^\'"]*)[\'"].*/gi;
@@ -90,7 +91,7 @@ module.exports = {
     var replacedBlock = blockContent.replace(re, function (wholeMatch, start, asset, end) {
 
       // Check if only the path was provided to leave the original asset name intact
-      asset = (!path.extname(block.asset) && /\//.test(block.asset)) ? path.join(block.asset, path.basename(asset)) : block.asset;
+      asset = (!path.extname(block.asset) && /\//.test(block.asset)) ? url.resolve(block.asset, path.basename(asset)) : block.asset;
 
       replaced = true;
 

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -21,7 +21,7 @@ var getBlocks = function (content, marker) {
    * - target|attribute (optional) i.e. dev, prod, release or attributes like [href] [src]
    * - value (optional) i.e. script.min.js
   */
-  var regStart = new RegExp('<!--\\s*' + marker + ':(\\[?[\\w-]+\\]?)(?::([\\w,]+))?(?:\\s*([^\\s]+)\\s*-->)*');
+  var regStart = new RegExp('<!--\\s*' + marker + ':(\\[?[\\w-]+\\]?)(?::([\\w,]+))?(?:\\s*(inline)\\s)?(?:\\s*([^\\s]+)\\s*-->)*');
 
   // <!-- /build -->
   var regEnd = new RegExp('(?:<!--\\s*)*\\/' + marker + '\\s*-->');
@@ -44,7 +44,8 @@ var getBlocks = function (content, marker) {
         type: attr ? 'attr': build[1],
         attr: attr,
         targets: !!build[2] ? build[2].split(',') : null,
-        asset: build[3],
+        inline: !!build[3],
+        asset: build[4],
         indent: /^\s*/.exec(line)[0],
         raw: []
       };

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -119,7 +119,7 @@ HTMLProcessor.prototype._strip = function (block, content) {
   var blockLine = this._getBlockLine(block);
   var blockContent = this._getBlockContent(block);
   var blockRegExp = utils.blockToRegExp(blockLine);
-  var result = content.replace(blockRegExp, '\n\n' + blockContent);
+  var result = content.replace(blockRegExp, '\r\n\r\n' + blockContent);
 
   return result;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ utils.read = function (filepath, encoding) {
   } else {
     contents = fs.readFileSync(filepath, 'utf-8');
   }
-  return contents;
+  return contents.replace(/\r\n|\r/g, '\n');
 };
 
 utils.exists = function (filepath) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "htmlprocessor",
   "description": "Process html file using special comments",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": {
     "name": "Denis Ciccale",
     "email": "dciccale@gmail.com",

--- a/test/expected/inline/inline.html
+++ b/test/expected/inline/inline.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <link rel="stylesheet" href="styles.css">
+
+    <style>
+html {
+    padding: 0;
+}
+
+html {
+    padding: 0;
+}
+    </style>
+
+    <style>
+html {
+    padding: 0;
+}
+    </style>
+
+</head>
+<body>
+
+    <script src="script_include.js"></script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+</body>
+</html>

--- a/test/fixtures/attr.html
+++ b/test/fixtures/attr.html
@@ -7,11 +7,11 @@
   </head>
   <body>
 
-    <!-- build:[src] /images -->
+    <!-- build:[src] /images/ -->
     <img alt="some image" src="/src/cat.png">
     <!-- /build -->
 
-    <!-- build:[src] /images -->
+    <!-- build:[src] /images/ -->
     <img src="/src/cat.png" alt="some image">
     <!-- /build -->
 

--- a/test/fixtures/inline.html
+++ b/test/fixtures/inline.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <!-- build:css styles.css -->
+    <link rel="stylesheet" href="styles1.css">
+    <link rel="stylesheet" href="styles2.css">
+    <!-- /build -->
+
+    <!-- build:css:dist inline -->
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css">
+    <!-- /build -->
+
+    <!-- build:css:dist inline styles.css -->
+    <link rel="stylesheet" href="styles1.css">
+    <link rel="stylesheet" href="styles2.css">
+    <!-- /build -->
+
+</head>
+<body>
+
+    <!-- build:js script_include.js -->
+    <script src="js/app/script1.js"></script>
+    <script src="js/app/script2.js"></script>
+    <!-- /build -->
+
+    <!-- build:js inline -->
+    <script src="script_include.js"></script>
+    <script src="script_include.js"></script>
+    <script src="script_include.js"></script>
+    <!-- /build -->
+
+    <!-- build:js:dist inline script_include.js -->
+    <script src="js/app/main.js"></script>
+    <script src="js/app/module.js"></script>
+    <!-- /build -->
+
+</body>
+</html>

--- a/test/fixtures/inline/inline.processed.html
+++ b/test/fixtures/inline/inline.processed.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Inline CSS</title>
+
+    <link rel="stylesheet" href="styles.css">
+
+    <style>
+html {
+    padding: 0;
+}
+
+html {
+    padding: 0;
+}
+    </style>
+
+    <style>
+html {
+    padding: 0;
+}
+    </style>
+
+</head>
+<body>
+
+    <script src="script_include.js"></script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+    <script>
+function c(a){return a.replace(/[\\\[\]\^$*+?.()|{}]/g,"\\$&")}
+var d;
+    </script>
+
+</body>
+</html>

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,3 @@
+html {
+    padding: 0;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -224,6 +224,7 @@ module.exports = {
 
     test.done();
   },
+
   template: function (test) {
     test.expect(1);
 
@@ -239,6 +240,21 @@ module.exports = {
     var actual = utils.read('test/fixtures/template/template.processed.html');
     var expected = utils.read('test/expected/template/template.html');
     test.equal(actual, expected, 'replace template data');
+
+    test.done();
+  },
+
+  inline: function (test) {
+    test.expect(1);
+
+    htmlprocessor({
+        src: ['test/fixtures/inline.html'],
+        dest: 'test/fixtures/inline/inline.processed.html'
+    });
+
+    var actual = utils.read('test/fixtures/inline/inline.processed.html');
+    var expected = utils.read('test/expected/inline/inline.html');
+    test.equal(actual, expected, 'should inline css and js for dist target');
 
     test.done();
   }


### PR DESCRIPTION
Greetings! Thank you for really useful utility Denis.

I've made some changes which allow to inline (a.k.a. embed) styles and scripts into output html file. There are two pull requests this is the first one and other is into [grunt-processhtml](https://github.com/dciccale/grunt-processhtml). Last one contains updated [README.MD](https://github.com/makovich/grunt-processhtml/blob/master/README.md).

In two words: it is possible to use `inline` modifier with `js` and `css` build types.

Hope it will be helpful for somebody.