### PR TITLE
Allow replacing with full WebUris

### DIFF
--- a/lib/blocktypes.js
+++ b/lib/blocktypes.js
@@ -12,6 +12,7 @@
 var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
+var validUrl = require('valid-url');
 
 // Define default block types
 module.exports = {
@@ -31,7 +32,9 @@ module.exports = {
     var replacedBlock = blockContent.replace(re, function (wholeMatch, start, asset, end) {
 
       // Check if only the path was provided to leave the original asset name intact
-      asset = (!path.extname(block.asset) && /\//.test(block.asset)) ? path.join(block.asset, path.basename(asset)) : block.asset;
+      asset = (!validUrl.isWebUri(block.asset) && !path.extname(block.asset) && /\//.test(block.asset)) ?
+                path.join(block.asset, path.basename(asset)) :
+                block.asset;
 
       replaced = true;
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "optimize"
   ],
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "valid-url": "^1.0.9"
   },
   "devDependencies": {
     "nodeunit": "~0.8.6"

--- a/test/expected/attr/attr.html
+++ b/test/expected/attr/attr.html
@@ -11,5 +11,7 @@
 
     <img src="/images/cat.png" alt="some image">
 
+    <a href="https://somedomain.com/link" />
+
   </body>
 </html>

--- a/test/fixtures/attr.html
+++ b/test/fixtures/attr.html
@@ -15,5 +15,9 @@
     <img src="/src/cat.png" alt="some image">
     <!-- /build -->
 
+    <!-- build:[href] https://somedomain.com/link -->
+    <a href="#" />
+    <!-- /build -->
+
   </body>
 </html>

--- a/test/fixtures/attr/attr.processed.html
+++ b/test/fixtures/attr/attr.processed.html
@@ -11,5 +11,7 @@
 
     <img src="/images/cat.png" alt="some image">
 
+    <a href="https:/somedomain.com/link/#" />
+
   </body>
 </html>

--- a/test/fixtures/attr/attr.processed.html
+++ b/test/fixtures/attr/attr.processed.html
@@ -11,7 +11,7 @@
 
     <img src="/images/cat.png" alt="some image">
 
-    <a href="https:/somedomain.com/link/#" />
+    <a href="https://somedomain.com/link" />
 
   </body>
 </html>


### PR DESCRIPTION
Hi there! 

I've been using `grunt-processhtml` task for some html post-processing and a recent update breaks my flow. 

The following line https://github.com/dciccale/node-htmlprocessor/blob/master/lib/blocktypes.js#L34 now tries to join paths of a block to be replaced. This means that trying to do a replace action with full-URL now result in an invalid URL. 

For example: 
```html
    <!-- build:[href] http://somedomain/app/ -->
    <base href="/">
    <!-- /build -->
```
will be processed as:
```html
    <base href="http:/somedomain/app/">
```