### PR TITLE
Create a list of files that were replaced and use that list to streamline the build process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,108 @@ Change the comment marker to `<!-- process --><!-- /process -->`
 $ htmlprocessor file-to-process.html -o processed/file.html --comment-marker process
 ```
 
+```bash
+$ htmlprocessor file-to-process.html -o processed/file.html --list wrk/replacement.list
+```
+
+Assumning you have this code in an HTML (or JSP)
+
+```bash
+        .
+        .
+        .
+        <!-- build:css content/myApplication.min.css -->
+        <link rel="stylesheet" href="js/bower_components/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" href="content/bootstrap-responsive.min.css" needed />
+        <link rel="stylesheet" href="js/bower_components/angular-date-range-picker/build/angular-date-range-picker.css" />
+        <link rel="stylesheet" href="js/bower_components/angular-grid/ng-grid.css" />
+        <link rel="stylesheet" href="content/styles.css" />
+        <link rel="stylesheet" href="content/myApplicationStyles.css" />
+        <link rel="stylesheet" href="content/angular-slider.css" />
+        <!--/build-->
+        .
+        .
+        .
+        <!-- build:js js/myApplication.min.js -->
+        <script src="js/bower_components/jquery/dist/jquery.js"></script>
+        <script src="js/bower_components/angular/angular.js"></script>
+        <script src="js/bower_components/angular-route/angular-route.js"></script>
+        <script src="js/bower_components/angular-animate/angular-animate.js"></script>
+        <script src="js/bower_components/angular-touch/angular-touch.js"></script>
+        <script src="js/angular-slider.js"></script>
+        <script src="js/bindonce.js"></script>
+        <script src="js/bower_components/angular-cookies/angular-cookies.js"></script>
+        <script src="js/bower_components/xdate/src/xdate.js"></script>
+        <script src="js/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+        <script src="js/bower_components/angular-grid/build/ng-grid.js"></script>
+        <script src="js/bower_components/angular-google-chart/ng-google-chart.js"></script>
+        <script src="js/bower_components/clone/clone.js"></script>
+
+        <!-- App libs -->
+        <script src="app/app.js"></script>
+        <script src="app/filters/filters.js"></script>
+        <script src="app/services/services.js"></script>
+        <script src="app/directives/various.js"></script>
+        <script src="app/controllers/controllers.js"></script>
+        <script src="app/controllers/settings.js"></script>
+        <script src="app/controllers/time.js"></script>
+        <script src="app/controllers/applications.js"></script>
+        <!--/build-->
+        .
+        .
+        .
+```
+
+The file "wrk/replacement.list" will contain something like this:
+
+```bash
+file-to-process.html:js/bower_components/bootstrap/dist/css/bootstrap.css
+file-to-process.html:content/bootstrap-responsive.min.css
+file-to-process.html:js/bower_components/angular-date-range-picker/build/angular-date-range-picker.css
+file-to-process.html:js/bower_components/angular-grid/ng-grid.css
+file-to-process.html:content/styles.css
+file-to-process.html:content/myApplicationStyles.css
+file-to-process.html:content/angular-slider.css
+file-to-process.html:js/bower_components/jquery/dist/jquery.js
+file-to-process.html:js/bower_components/angular/angular.js
+file-to-process.html:js/bower_components/angular-route/angular-route.js
+file-to-process.html:js/bower_components/angular-animate/angular-animate.js
+file-to-process.html:js/bower_components/angular-touch/angular-touch.js
+file-to-process.html:js/angular-slider.js
+file-to-process.html:js/bindonce.js
+file-to-process.html:js/bower_components/angular-cookies/angular-cookies.js
+file-to-process.html:js/bower_components/xdate/src/xdate.js
+file-to-process.html:js/bower_components/angular-bootstrap/ui-bootstrap-tpls.js
+file-to-process.html:js/bower_components/angular-grid/build/ng-grid.js
+file-to-process.html:js/bower_components/angular-google-chart/ng-google-chart.js
+file-to-process.html:js/bower_components/clone/clone.js
+file-to-process.html:app/app.js
+file-to-process.html:app/filters/filters.js
+file-to-process.html:app/services/services.js
+file-to-process.html:app/directives/various.js
+file-to-process.html:app/controllers/controllers.js
+file-to-process.html:app/controllers/settings.js
+file-to-process.html:app/controllers/time.js
+file-to-process.html:app/controllers/applications.js
+```
+
+And you can use these commands to concatenate and eventually minify without having to update the build to tell
+it where it should pickup each files. Also, in this way it orders the global file content in the same manner
+as your individual includes originally were.
+
+```bash
+bash -c "cat `cat wrk/replacement.list | grep '\.js$' | cut -d: -f2` > dist/js/myApplication.js"
+bash -c "cat `cat wrk/replacement.list | grep '\.css$' | cut -d: -f2` > dist/css/myApplication.css"
+```
+
+If you processed more than a single "html" file, you can change the grep like this:
+
+```bash
+... | grep 'file-to-process.html:.*\.js$' | ... > dist/js/myApplication.js
+... | grep 'other-file-to-process.html:.*\.js$' | ... > dist/js/myApplicationOther.js
+```
+
+The file name is included in the list file for that very purpose.
+
 ## License
 See [LICENSE.txt](https://raw.github.com/dciccale/node-htmlprocessor/master/LICENSE-MIT)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Change the comment marker to `<!-- process --><!-- /process -->`
 $ htmlprocessor file-to-process.html -o processed/file.html --comment-marker process
 ```
 
+## New option
+
+Create a list of files that were replaced and use that list to streamline the build process.
+
+Note: This new option does not affect in any way the previous existing functionality (i.e. it's backward compatible).
+
 ```bash
 $ htmlprocessor file-to-process.html -o processed/file.html --list wrk/replacement.list
 ```
@@ -151,7 +157,7 @@ If you processed more than a single "html" file, you can change the grep like th
 ... | grep 'other-file-to-process.html:.*\.js$' | ... > dist/js/myApplicationOther.js
 ```
 
-The file name is included in the list file for that very purpose.
+The originating file name is included in the list file for that very purpose.
 
 ## License
 See [LICENSE.txt](https://raw.github.com/dciccale/node-htmlprocessor/master/LICENSE-MIT)

--- a/bin/htmlprocessor
+++ b/bin/htmlprocessor
@@ -37,13 +37,17 @@ while (args.length > 0) {
     case '--include-base':
       options.includeBase = args.shift();
       break;
+    case '-l':
+    case '--list':
+      options.list = args.shift();
+      break;
     case '-r':
     case '--recursive':
       options.recursive = args.shift();
       break;
     case '-s':
     case '--strip':
-      options.strip = true
+      options.strip = true;
       break;
     case '-v':
     case '--version':
@@ -59,9 +63,10 @@ while (args.length > 0) {
       break;
     case '-h':
     case '--help':
-      console.log('Usage: htmlprocessor file-to-process.html [options]\n')
+      console.log('Usage: htmlprocessor file-to-process.html [options]\n');
       console.log('-h|--help             display this help message');
       console.log('-v|--version          display the version number');
+      console.log('-l|--list             file to output list of replaced files');
       console.log('-o|--output           file to output processed HTML to');
       console.log('-d|--data             pass a JSON file to processor');
       console.log('-e|--env              specify an environment');

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
 var path = require('path');
 var fs = require('fs');
 var HTMLProcessor = require('./lib/htmlprocessor');
-var utils = require('./lib/utils')
+var utils = require('./lib/utils');
 
 module.exports = function (files, options) {
 
@@ -47,11 +47,19 @@ module.exports = function (files, options) {
     }
   }
 
+  // create options.list directory if needed
+  if (options.list) {
+    utils.mkdir(path.dirname(options.list));
+  }
+
   files.src.forEach(function (filepath) {
     var content = html.process(filepath);
     var dest = getOutputPath(filepath);
 
     fs.writeFileSync(dest, content);
     console.log('File', '"' + dest + '"', 'created.');
+    if (options.list) {
+      console.log('File', '"' + options.list + '"', 'created.');
+    }
   });
 };

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (files, options) {
   }
 
   // create options.list directory if needed
-  if (options.list) {
+  if (options && options.list) {
     utils.mkdir(path.dirname(options.list));
   }
 
@@ -58,7 +58,7 @@ module.exports = function (files, options) {
 
     fs.writeFileSync(dest, content);
     console.log('File', '"' + dest + '"', 'created.');
-    if (options.list) {
+    if (options && options.list) {
       console.log('File', '"' + options.list + '"', 'created.');
     }
   });

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -15,8 +15,7 @@ var utils = require('./utils');
 var blockTypes = require('./blocktypes');
 var listFile = null;
 
-var getBlocks = function (content, options, filepath) {
-  var marker = options.commentMarker;
+var getBlocks = function (content, marker, filepath) {
   /*
    * <!-- build:<type>[:target] [value] -->
    * - type (required) js, css, attr, remove, template, include
@@ -61,7 +60,7 @@ var getBlocks = function (content, options, filepath) {
 
     if (inside && block) {
       block.raw.push(line);
-      if (options.list) {
+      if (listFile) {
         var match = line.match(cssHref);
         if (match != null) {
           //call the write option where you need to append new data
@@ -174,7 +173,7 @@ HTMLProcessor.prototype.processContent = function (content, filepath) {
   this.content = content;
   this.linefeed = /\r\n/g.test(this.content) ? '\r\n' : '\n';
 
-  if (this.options.list) {
+  if (this.options && this.options.list) {
     //Set our log file as a writestream variable with the 'a' flag
     listFile = fs.createWriteStream(this.options.list, {
       flags:    "a",
@@ -184,7 +183,7 @@ HTMLProcessor.prototype.processContent = function (content, filepath) {
   }
 
   // Parse the file content to look for build comment blocks
-  var blocks = getBlocks(this.content, this.options, filepath);
+  var blocks = getBlocks(this.content, this.options.commentMarker, filepath);
 
   // Replace found blocks
   content = this._replaceBlocks(blocks, filepath);

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -13,8 +13,10 @@ var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
 var blockTypes = require('./blocktypes');
+var listFile = null;
 
-var getBlocks = function (content, marker) {
+var getBlocks = function (content, options, filepath) {
+  var marker = options.commentMarker;
   /*
    * <!-- build:<type>[:target] [value] -->
    * - type (required) js, css, attr, remove, template, include
@@ -25,6 +27,12 @@ var getBlocks = function (content, marker) {
 
   // <!-- /build -->
   var regEnd = new RegExp('(?:<!--\\s*)*\\/' + marker + '\\s*-->');
+
+  // <link rel="stylesheet" href="js/bower_components/bootstrap/dist/css/bootstrap.css" />
+  var cssHref = new RegExp('^\\s*<\\s*\\LINK.*HREF=["' + "'" + ']([^"' + "'" + ']*)["' + "'" + '].*$', 'i');
+
+  // <script src="js/bower_components/xdate/src/xdate.js"></script>
+  var jsSrc = new RegExp('^\\s*<\\s*\\SCRIPT.*SRC=["' + "'" + ']([^"' + "'" + ']*)["' + "'" + '].*$', 'i');
 
   // Normalize line endings and split in lines
   var lines = content.replace(/\r\n/g, '\n').split(/\n/);
@@ -53,6 +61,19 @@ var getBlocks = function (content, marker) {
 
     if (inside && block) {
       block.raw.push(line);
+      if (options.list) {
+        var match = line.match(cssHref);
+        if (match != null) {
+          //call the write option where you need to append new data
+          listFile.write(filepath + ":" + match[1] + "\n");
+        }
+        else {
+          match = line.match(jsSrc);
+          if (match != null) {
+            listFile.write(filepath + ":" + match[1] + "\n");
+          }
+        }
+      }
     }
 
     if (inside && endbuild) {
@@ -153,11 +174,20 @@ HTMLProcessor.prototype.processContent = function (content, filepath) {
   this.content = content;
   this.linefeed = /\r\n/g.test(this.content) ? '\r\n' : '\n';
 
+  if (this.options.list) {
+    //Set our log file as a writestream variable with the 'a' flag
+    listFile = fs.createWriteStream(this.options.list, {
+      flags:    "a",
+      encoding: "encoding",
+      mode:    parseInt('744', 8)
+    });
+  }
+
   // Parse the file content to look for build comment blocks
-  var blocks = getBlocks(this.content, this.options.commentMarker);
+  var blocks = getBlocks(this.content, this.options, filepath);
 
   // Replace found blocks
-  var content = this._replaceBlocks(blocks, filepath);
+  content = this._replaceBlocks(blocks, filepath);
 
   return content;
 };


### PR DESCRIPTION
New option: --list replacementListOf.files

Create a list of files that were replaced and use that list to streamline the build process.

Note: This new option does not affect in any way the previous existing functionality (i.e. it's backward compatible). Grunt, gulp and other build tools may need to be updated in order to use this new option.

Further details can be found in the README file.

Typically a "concatenate" process could be similar to this below. If you add scripts, or css to your project, they would be automatically picked up.

bash -c "cat \`cat wrk/replacement.list | grep '\.js$' | cut -d: -f2\` > dist/js/myApplication.js"
bash -c "cat \`cat wrk/replacement.list | grep '\.css$' | cut -d: -f2\` > dist/css/myApplication.css"

The originating file name is included in the list file in case there were more than one HTML processed.

If you don't intend to pull this request in the master please let me know so we can aim our development accordingly.

Ps. Some additional consideration might need to be given to process files with spaces in their name. There are different options on how to solve that. All easy to implement

The npm test work fine in a windows environment. I believe the two that fail now will be fixed when the other pull request (about tests failing) is implemented.