### PR TITLE
Added tag closing when replacing the link tag href

### DIFF
--- a/lib/blocktypes/css.js
+++ b/lib/blocktypes/css.js
@@ -18,7 +18,7 @@ function css(content, block, blockLine, blockContent, filepath) {
     return content.split(blockLine).join(replacement);
   }
 
-  return content.replace(blockLine, block.indent + '<link rel="stylesheet" href="' + block.asset + '">');
+  return content.replace(blockLine, block.indent + '<link rel="stylesheet" href="' + block.asset + '"/>');
 }
 
 function obtainStyles(block, html, baseDir) {

--- a/test/expected/conditional_ie/conditional_ie.html
+++ b/test/expected/conditional_ie/conditional_ie.html
@@ -6,7 +6,7 @@
     <title>Conditional IE statement</title>
     <!--[if lte IE 8]>
       <script src="ie8script.js"></script>
-      <link rel="stylesheet" href="ie8.min.css">
+      <link rel="stylesheet" href="ie8.min.css"/>
     <![endif]-->
   </head>
   <body>

--- a/test/expected/inline/inline.html
+++ b/test/expected/inline/inline.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Inline CSS</title>
 
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css"/>
 
     <style>
 html {

--- a/test/expected/recursive/recursive.html
+++ b/test/expected/recursive/recursive.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Recursive process included files</title>
 
-    <link rel="stylesheet" href="styles.min.css">
+    <link rel="stylesheet" href="styles.min.css"/>
 
 <script src="script.min.js"></script>
   </head>


### PR DESCRIPTION
I noticed that my XHTML pages were being made invalid by processing them through processhtml, since the css block type was replacing the whole `link` tag with a non-self-closing HTML5 void tag.

Thus, in my opinion, since the tag specified as `<link rel="stylesheet" href="http://whatever"/>` is still valid HTML5 while also being valid XHTML, it may be better to have the replace block include the trailing slash.

I could have also added some logic to include the trailing slash only if it was already present in the original HTML, but since adding it should do no harm in files that didn't have it it should be simpler this way.