### PR TITLE
Added checksum versioning for assets

### DIFF
--- a/lib/blocktypes/js.js
+++ b/lib/blocktypes/js.js
@@ -2,15 +2,28 @@
 
 var path = require('path');
 var helpers = require('./helpers');
+var srcRegEx = /.*src=[\'"]([^\'"]*)[\'"].*/gi;
+var crypto = require('crypto');
+var fs = require('fs');
 
 module.exports = js;
 
 function js(content, block, blockLine, blockContent, filepath) {
   var scripts = [];
   var replacement;
+  var assetContent;
+  var baseDir = this.options.includeBase || path.dirname(filepath);
+  var md5sum;
+  var newName;
 
-  if (block.inline) {
-    scripts = obtainScripts(block, blockContent, this.options.includeBase || path.dirname(filepath));
+  if (block.checksum) {
+    assetContent = obtainScripts(block, blockContent, baseDir)[0];
+    md5sum = crypto.createHash('md5').update(assetContent).digest('hex');
+    newName = block.asset.replace(/((\.min)?\.js)$/, '.' + md5sum.substr(0, 8) + '$1');
+    fs.renameSync(path.join(baseDir, block.asset), path.join(baseDir, newName));
+    block.asset = newName;
+  } else if (block.inline) {
+    scripts = obtainScripts(block, blockContent, baseDir);
     replacement = block.indent + '<script>' + this.linefeed +
                   scripts.join(this.linefeed) +
                   block.indent + '</script>';
@@ -22,6 +35,5 @@ function js(content, block, blockLine, blockContent, filepath) {
 }
 
 function obtainScripts(block, html, baseDir) {
-  var srcRegEx = /.*src=[\'"]([^\'"]*)[\'"].*/gi;
   return helpers.obtainAssets(srcRegEx, block, html, baseDir);
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -33,7 +33,7 @@ function Parser(options) {
    * - target|attribute (optional) i.e. dev, prod, release or attributes like [href] [src]
    * - value (optional) i.e. script.min.js
   */
-  this.regStart = new RegExp('<!--\\s*' + this.options.commentMarker + ':(\\[?[\\w-]+\\]?)(?::([\\w,]+))?(?:\\s*(inline)\\s)?(?:\\s*([^\\s]+)\\s*-->)*');
+  this.regStart = new RegExp('<!--\\s*' + this.options.commentMarker + ':(\\[?[\\w-]+\\]?)(?::([\\w,]+))?(?:\\s*(inline|checksum)\\s)?(?:\\s*([^\\s]+)\\s*-->)*');
 
   // <!-- /build -->
   this.regEnd = new RegExp('(?:<!--\\s*)*\\/' + this.options.commentMarker + '\\s*-->');
@@ -64,7 +64,8 @@ Parser.prototype.getBlocks = function (content, filePath) {
         type: attr ? 'attr': build[1],
         attr: attr,
         targets: !!build[2] ? build[2].split(',') : null,
-        inline: !!build[3],
+        inline: build[3] === 'inline',
+        checksum: build[3] === 'checksum',
         asset: build[4],
         indent: /^\s*/.exec(line)[0],
         raw: []


### PR DESCRIPTION
I added a new option to js-build to rename the asset with its md5-checksum.

```html
<!-- build:js checksum js/lib.min.js -->
<script src="src1.js"></script>
<script src="src2.js"></script>
<!-- /build -->
```

becomes:

```html
<script src="js/lib.1a3babd9.min.js"></script>
```

The md5 of file js/lib.min.js is:
1a3babd93efc82c31224be5d92a811cc

of course js/lib.min.js is allso renamed on filesystem.

Let me know what you think about this.
I'm willing to add the same for css.