### PR TITLE
Fix for inline HTML

### DIFF
--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -107,6 +107,14 @@ HTMLProcessor.prototype.processContent = function (content, filePath) {
   this.content = content;
   this.linefeed = os.EOL;
   this.content = this.content.replace(/\r\n|\r|\n/g, this.linefeed);
+  
+  // insert new lines before start and end comment tags
+  var commentRegex = /(<!--[\s\S]*?-->)/g;
+  var matches = this.content.match(commentRegex);
+  matches.forEach(match => {
+    var newLineContent = this.linefeed + match + this.linefeed;
+    this.content = this.content.replace(match, newLineContent);
+  });
 
   // Parse the file content to look for build comment blocks
   var blocks = this.parser.getBlocks(this.content, filePath);

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -111,10 +111,10 @@ HTMLProcessor.prototype.processContent = function (content, filePath) {
   // Insert new lines before start and end comment tags
   var commentRegex = /<!--[\s\S]*?-->/g;
   var matches = this.content.match(commentRegex);
-  matches.forEach(match => {
+  matches.forEach(function (match) {
     var newLineContent = this.linefeed + match + this.linefeed;
     this.content = this.content.replace(new RegExp(match, "g"), newLineContent);
-  });
+  }, this);
   
   // Parse the file content to look for build comment blocks
   var blocks = this.parser.getBlocks(this.content, filePath);

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -108,14 +108,14 @@ HTMLProcessor.prototype.processContent = function (content, filePath) {
   this.linefeed = os.EOL;
   this.content = this.content.replace(/\r\n|\r|\n/g, this.linefeed);
   
-  // insert new lines before start and end comment tags
-  var commentRegex = /(<!--[\s\S]*?-->)/g;
+  // Insert new lines before start and end comment tags
+  var commentRegex = /<!--[\s\S]*?-->/g;
   var matches = this.content.match(commentRegex);
   matches.forEach(match => {
     var newLineContent = this.linefeed + match + this.linefeed;
-    this.content = this.content.replace(match, newLineContent);
+    this.content = this.content.replace(new RegExp(match, "g"), newLineContent);
   });
-
+  
   // Parse the file content to look for build comment blocks
   var blocks = this.parser.getBlocks(this.content, filePath);
 


### PR DESCRIPTION
Regarding my question at https://github.com/dciccale/grunt-processhtml/issues/108, when an inline HTML is used, the result is incorrect.  
This fix is quick and dirty. Since the parser (and replacing) is line based (as far as I could understand), the solution is to insert new lines before and after comment tags.

P.S. This is my first PR in JavaScript. :)