### PR TITLE
Update dependencies to prevent audit warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - "6"
+  - "8"
+  - "10"
 after_script:
   - npm run coveralls

--- a/lib/blocktypes/template.js
+++ b/lib/blocktypes/template.js
@@ -5,10 +5,10 @@ var utils = require('../utils');
 module.exports = template;
 
 function template(content, block, blockLine, blockContent) {
-  var compiledTmpl = utils._.template(blockContent, this.data, this.options.templateSettings);
+  var compiledTmpl = utils._.template(blockContent, this.options.templateSettings);
 
   // Clean template output and fix indent
-  compiledTmpl = block.indent + compiledTmpl.trim().replace(/(\r\n|\n)\s*/g, '$1' + block.indent);
+  compiledTmpl = block.indent + compiledTmpl(this.data).trim().replace(/(\r\n|\n)\s*/g, '$1' + block.indent);
 
   return content.replace(blockLine, compiledTmpl.replace(/\$/g, '$$$'));
 }

--- a/lib/htmlprocessor.js
+++ b/lib/htmlprocessor.js
@@ -117,7 +117,11 @@ HTMLProcessor.prototype.processContent = function (content, filePath) {
   return content;
 };
 
-HTMLProcessor.prototype.template = utils._.template;
+// Lodash 2.4 like template function
+HTMLProcessor.prototype.template = function(text, data, options) {
+  let compiledTemplate = utils._.template(text, options);
+  return compiledTemplate(data);
+};
 
 // Export the processor
 module.exports = HTMLProcessor;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -99,10 +99,10 @@ Parser.prototype._writeToList = function (line, filePath) {
   if (match) {
     this.listFile.write(filePath + ':' + match[1] + '\n');
   }
-}
+};
 
 Parser.prototype._getMatch = function (line) {
   var matchCss = line.match(this.cssHref);
   var matchJs = line.match(this.jsSrc);
   return matchCss || matchJs || null;
-}
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,13 +20,13 @@ module.exports = {
   _: _
 };
 
-function read(filepath, encoding) {
+function read(filepath) {
   return fs.readFileSync(filepath, 'utf-8');
-};
+}
 
 function exists(filepath) {
   return filepath && fs.existsSync(filepath);
-};
+}
 
 // courtesy of grunt
 function mkdir(dirpath, mode) {
@@ -47,4 +47,4 @@ function mkdir(dirpath, mode) {
     }
     return parts;
   }, '');
-};
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "optimize"
   ],
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "coveralls": "^2.11.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "coveralls": "^2.11.3",
+    "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
     "mocha": "^2.2.5"
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   "devDependencies": {
     "coveralls": "^3.0.2",
     "istanbul": "^0.4.5",
-    "mocha": "^2.2.5"
+    "mocha": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.3",
-    "istanbul": "^0.3.17",
+    "istanbul": "^0.4.5",
     "mocha": "^2.2.5"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -420,3 +420,19 @@ describe('list', function () {
     });
   });
 });
+
+describe('lodash template', function() {
+  it ('should offer a lodash 2.4 compatible template function in prototype', function() {
+    var text = 'hello {{ name }}!';
+    var data = { 'name': 'mustache' };
+    var options = { 'interpolate': /{{([\s\S]+?)}}/g };
+    var processorInstance = htmlprocessor({
+        src: []
+    });
+    var actual = processorInstance.template(text, data, options);
+    // var actual = utils._.template(text, options)(data);
+    var expected = 'hello mustache!';
+
+    assert.equal(actual, expected);
+  })
+});


### PR DESCRIPTION
This PR updates dependencies. Most importantly lodash, to prevent audit warnings.

Before: found 11 vulnerabilities (2 low, 5 moderate, 3 high, 1 critical) in 174 scanned packages
After: found 0 vulnerabilities (better, right?)

As lodash is an important part of htmlprocessor, there may be functionality changes (!)

Test added for the template prototype method in htmlprocessor.js (line 120) as it is used by dependencies, was not tested, and params changed by lodash. This is one obvious functionality change.
 