### PR TITLE
update lodash to 4.17.21 to resolve CVE-2021-23337

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "optimize"
   ],
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
CVE: https://nvd.nist.gov/vuln/detail/CVE-2021-23337
Note that all tests run without error, so there appear to be no breaking changes introduced.